### PR TITLE
Handle stacks (xdg_toplevel::set_parent relationships)

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -38,6 +38,7 @@ struct roots_view {
 	const struct roots_view_interface *impl;
 	struct roots_desktop *desktop;
 	struct wl_list link; // roots_desktop::views
+	struct wl_list parent_link; // roots_view::stack
 
 	struct wlr_box box;
 	float rotation;
@@ -61,8 +62,11 @@ struct roots_view {
 		uint32_t width, height;
 	} pending_move_resize;
 
+	struct roots_view *parent;
+	struct wl_list stack; // roots_view::link
+
 	struct wlr_surface *wlr_surface;
-	struct wl_list children; // roots_view_child::link
+	struct wl_list child_surfaces; // roots_view_child::link
 
 	struct wlr_foreign_toplevel_handle_v1 *toplevel_handle;
 	struct wl_listener toplevel_handle_request_maximize;
@@ -93,6 +97,7 @@ struct roots_xdg_surface_v6 {
 	struct wl_listener request_fullscreen;
 	struct wl_listener set_title;
 	struct wl_listener set_app_id;
+	struct wl_listener set_parent;
 
 	struct wl_listener surface_commit;
 
@@ -116,6 +121,7 @@ struct roots_xdg_surface {
 	struct wl_listener request_fullscreen;
 	struct wl_listener set_title;
 	struct wl_listener set_app_id;
+	struct wl_listener set_parent;
 
 	struct wl_listener surface_commit;
 
@@ -223,6 +229,7 @@ bool view_center(struct roots_view *view);
 void view_setup(struct roots_view *view);
 void view_teardown(struct roots_view *view);
 void view_set_title(struct roots_view *view, const char *title);
+void view_set_parent(struct roots_view *view, struct roots_view *parent);
 void view_set_app_id(struct roots_view *view, const char *app_id);
 void view_create_foreign_toplevel_handle(struct roots_view *view);
 void view_get_deco_box(const struct roots_view *view, struct wlr_box *box);

--- a/seat.c
+++ b/seat.c
@@ -1326,6 +1326,7 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 	if (view != NULL) {
 		wl_list_remove(&view->link);
 		wl_list_insert(&seat->input->server->desktop->views, &view->link);
+		view_damage_whole(view);
 	}
 
 	bool unfullscreen = true;
@@ -1396,8 +1397,6 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 
 	wl_list_remove(&seat_view->link);
 	wl_list_insert(&seat->views, &seat_view->link);
-
-	view_damage_whole(view);
 
 	if (seat->focused_layer) {
 		return;

--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -276,6 +276,7 @@ static void destroy(struct roots_view *view) {
 	wl_list_remove(&roots_xdg_surface->request_fullscreen.link);
 	wl_list_remove(&roots_xdg_surface->set_title.link);
 	wl_list_remove(&roots_xdg_surface->set_app_id.link);
+	wl_list_remove(&roots_xdg_surface->set_parent.link);
 	roots_xdg_surface->xdg_surface->data = NULL;
 	free(roots_xdg_surface);
 }
@@ -362,6 +363,18 @@ static void handle_set_app_id(struct wl_listener *listener, void *data) {
 
 	view_set_app_id(&roots_xdg_surface->view,
 			roots_xdg_surface->xdg_surface->toplevel->app_id);
+}
+
+static void handle_set_parent(struct wl_listener *listener, void *data) {
+	struct roots_xdg_surface *roots_xdg_surface =
+		wl_container_of(listener, roots_xdg_surface, set_parent);
+
+	if (roots_xdg_surface->xdg_surface->toplevel->parent) {
+		struct roots_xdg_surface *parent = roots_xdg_surface->xdg_surface->toplevel->parent->data;
+		view_set_parent(&roots_xdg_surface->view, &parent->view);
+	} else {
+		view_set_parent(&roots_xdg_surface->view, NULL);
+	}
 }
 
 static void handle_surface_commit(struct wl_listener *listener, void *data) {
@@ -453,6 +466,7 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 
 	wlr_log(WLR_DEBUG, "new xdg toplevel: title=%s, app_id=%s",
 		surface->toplevel->title, surface->toplevel->app_id);
+
 	wlr_xdg_surface_ping(surface);
 
 	struct roots_xdg_surface *roots_surface =
@@ -465,6 +479,11 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	roots_surface->xdg_surface = surface;
 	surface->data = roots_surface;
 
+	// catch up with state accumulated before commiting
+	if (surface->toplevel->parent) {
+		struct roots_xdg_surface *parent = surface->toplevel->parent->data;
+		view_set_parent(&roots_surface->view, &parent->view);
+	}
 	view_maximize(&roots_surface->view, surface->toplevel->client_pending.maximized);
 	view_set_fullscreen(&roots_surface->view, surface->toplevel->client_pending.fullscreen,
 		surface->toplevel->client_pending.fullscreen_output);
@@ -494,7 +513,9 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	wl_signal_add(&surface->toplevel->events.set_title, &roots_surface->set_title);
 	roots_surface->set_app_id.notify = handle_set_app_id;
 	wl_signal_add(&surface->toplevel->events.set_app_id,
-			&roots_surface->set_app_id);
+		&roots_surface->set_app_id);
+	roots_surface->set_parent.notify = handle_set_parent;
+	wl_signal_add(&surface->toplevel->events.set_parent, &roots_surface->set_parent);
 	roots_surface->new_popup.notify = handle_new_popup;
 	wl_signal_add(&surface->events.new_popup, &roots_surface->new_popup);
 }


### PR DESCRIPTION
So far, rootston simply ignored the parent-child relationships as set by `xdg_toplevel::set_parent`. This PR implements the behavior specified by the protocol, so the child surfaces stay on top of their parents.

I've renamed `children` member to `child_surfaces` in order to try to make it a bit less confusing, as it has nothing to do with a member called `parent`.