### PR TITLE
view: Null-check output in view_arrange_maximized

### DIFF
--- a/view.c
+++ b/view.c
@@ -211,6 +211,10 @@ void view_arrange_maximized(struct roots_view *view) {
 	view_get_box(view, &view_box);
 
 	struct wlr_output *output = view_get_output(view);
+	if (!output) {
+		return;
+	}
+
 	struct roots_output *roots_output = output->data;
 	struct wlr_box *output_box =
 		wlr_output_layout_get_box(view->desktop->layout, output);


### PR DESCRIPTION
Otherwise it segfaults on surface mapping when no outputs are attached.
The easiest way to reproduce is to close the nested phoc's window and
then launch some application from the command line.

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==3078==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000228 (pc 0x56151b080fa1 bp 0x7ffe7104bd90 sp 0x7ffe7104bcd0 T0)
==3078==The signal is caused by a READ memory access.
==3078==Hint: address points to the zero page.
    #0 0x56151b080fa0 in view_arrange_maximized ../src/view.c:248
    #1 0x56151b081647 in view_arrange_maximized ../src/view.c:408
    #2 0x56151b081647 in view_maximize ../src/view.c:282
    #3 0x56151b0840d9 in view_setup ../src/view.c:642
    #4 0x56151b086a81 in handle_map ../src/xdg_shell.c:448
    #5 0x56151b14463c in wlr_signal_emit_safe ../subprojects/wlroots/util/signal.c:29
    #6 0x56151b108085 in handle_xdg_surface_commit ../subprojects/wlroots/types/xdg_shell/wlr_xdg_surface.c:356
    #7 0x56151b1395a9 in surface_commit_pending ../subprojects/wlroots/types/wlr_surface.c:372
    #8 0x56151b139f67 in surface_commit ../subprojects/wlroots/types/wlr_surface.c:444
    #9 0x7f80ff36a6cf in ffi_call_unix64 (/lib64/libffi.so.6+0x66cf)
    #10 0x7f80ff36a09f in ffi_call (/lib64/libffi.so.6+0x609f)
    #11 0x7f810040b82e  (/lib64/libwayland-server.so.0+0xc82e)
    #12 0x7f8100408192  (/lib64/libwayland-server.so.0+0x9192)
    #13 0x7f81004097f1 in wl_event_loop_dispatch (/lib64/libwayland-server.so.0+0xa7f1)
    #14 0x56151b069c9a in wayland_event_source_dispatch ../src/main.c:49
    #15 0x7f810066fcf3 in g_main_context_dispatch (/lib64/libglib-2.0.so.0+0x68cf3)
    #16 0x7f8100671b10  (/lib64/libglib-2.0.so.0+0x6ab10)
    #17 0x7f8100672a62 in g_main_loop_run (/lib64/libglib-2.0.so.0+0x6ba62)
    #18 0x56151b05443d in main ../src/main.c:207
    #19 0x7f80ffa86ee2 in __libc_start_main (/lib64/libc.so.6+0x26ee2)
    #20 0x56151b055acd in _start (/home/dos/git/purism/phoc/build/src/phoc+0x64acd)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV ../src/view.c:248 in view_arrange_maximized
==3078==ABORTING
```