### PR TITLE
view: Rename "maximized" argument in view_maximize

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -213,7 +213,7 @@ void view_move(struct roots_view *view, double x, double y);
 void view_resize(struct roots_view *view, uint32_t width, uint32_t height);
 void view_move_resize(struct roots_view *view, double x, double y,
 	uint32_t width, uint32_t height);
-void view_maximize(struct roots_view *view, bool maximized);
+void view_maximize(struct roots_view *view, bool maximize);
 void view_set_fullscreen(struct roots_view *view, bool fullscreen,
 	struct wlr_output *output);
 void view_rotate(struct roots_view *view, float rotation);

--- a/view.c
+++ b/view.c
@@ -225,21 +225,21 @@ void view_arrange_maximized(struct roots_view *view) {
 	view_rotate(view, 0);
 }
 
-void view_maximize(struct roots_view *view, bool maximized) {
-	if (view->maximized == maximized || view->fullscreen_output != NULL) {
+void view_maximize(struct roots_view *view, bool maximize) {
+	if (view->maximized == maximize || view->fullscreen_output != NULL) {
 		return;
 	}
 
 	if (view->impl->maximize) {
-		view->impl->maximize(view, maximized);
+		view->impl->maximize(view, maximize);
 	}
 
 	if (view->toplevel_handle) {
 		wlr_foreign_toplevel_handle_v1_set_maximized(view->toplevel_handle,
-			maximized);
+			maximize);
 	}
 
-	if (!view->maximized && maximized) {
+	if (!view->maximized && maximize) {
 		view->maximized = true;
 		view->saved.x = view->box.x;
 		view->saved.y = view->box.y;
@@ -250,7 +250,7 @@ void view_maximize(struct roots_view *view, bool maximized) {
 		view_arrange_maximized(view);
 	}
 
-	if (view->maximized && !maximized) {
+	if (view->maximized && !maximize) {
 		view->maximized = false;
 
 		view_move_resize(view, view->saved.x, view->saved.y, view->saved.width,


### PR DESCRIPTION
This argument conveys a new state to be set, not the current state,
making constructs like "if (maximized)" a bit misguiding.