### PR TITLE
Fixes for wlr-foreign-toplevel-management

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -47,6 +47,9 @@ struct roots_view {
 	int border_width;
 	int titlebar_height;
 
+	char *title;
+	char *app_id;
+
 	bool maximized;
 	struct roots_output *fullscreen_output;
 	struct {

--- a/view.c
+++ b/view.c
@@ -1,3 +1,6 @@
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -15,6 +18,8 @@ void view_init(struct roots_view *view, const struct roots_view_interface *impl,
 	view->type = type;
 	view->desktop = desktop;
 	view->alpha = 1.0f;
+	view->title = NULL;
+	view->app_id = NULL;
 	wl_signal_init(&view->events.unmap);
 	wl_signal_init(&view->events.destroy);
 	wl_list_init(&view->children);
@@ -548,6 +553,15 @@ void view_setup(struct roots_view *view) {
 	}
 
 	view_update_output(view, NULL);
+
+	wlr_foreign_toplevel_handle_v1_set_fullscreen(view->toplevel_handle,
+	                                              view->fullscreen_output != NULL);
+	wlr_foreign_toplevel_handle_v1_set_maximized(view->toplevel_handle,
+	                                             view->maximized);
+	wlr_foreign_toplevel_handle_v1_set_title(view->toplevel_handle,
+	                                         view->title ?: "");
+	wlr_foreign_toplevel_handle_v1_set_app_id(view->toplevel_handle,
+	                                          view->app_id ?: "");
 }
 
 void view_apply_damage(struct roots_view *view) {
@@ -613,14 +627,20 @@ void view_update_decorated(struct roots_view *view, bool decorated) {
 }
 
 void view_set_title(struct roots_view *view, const char *title) {
+	free(view->title);
+	view->title = title ? strdup(title) : NULL;
+
 	if (view->toplevel_handle) {
-		wlr_foreign_toplevel_handle_v1_set_title(view->toplevel_handle, title);
+		wlr_foreign_toplevel_handle_v1_set_title(view->toplevel_handle, title ?: "");
 	}
 }
 
 void view_set_app_id(struct roots_view *view, const char *app_id) {
+	free(view->app_id);
+	view->app_id = app_id ? strdup(app_id) : NULL;
+
 	if (view->toplevel_handle) {
-		wlr_foreign_toplevel_handle_v1_set_app_id(view->toplevel_handle, app_id);
+		wlr_foreign_toplevel_handle_v1_set_app_id(view->toplevel_handle, app_id ?: "");
 	}
 }
 

--- a/view.c
+++ b/view.c
@@ -540,13 +540,13 @@ void view_initial_focus(struct roots_view *view) {
 }
 
 void view_setup(struct roots_view *view) {
+	view_create_foreign_toplevel_handle(view);
 	view_initial_focus(view);
 
 	if (view->fullscreen_output == NULL && !view->maximized) {
 		view_center(view);
 	}
 
-	view_create_foreign_toplevel_handle(view);
 	view_update_output(view, NULL);
 }
 

--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -420,11 +420,6 @@ static void handle_map(struct wl_listener *listener, void *data) {
 
 	view_map(view, roots_xdg_surface->xdg_surface->surface);
 	view_setup(view);
-
-	wlr_foreign_toplevel_handle_v1_set_title(view->toplevel_handle,
-			roots_xdg_surface->xdg_surface->toplevel->title ?: "none");
-	wlr_foreign_toplevel_handle_v1_set_app_id(view->toplevel_handle,
-			roots_xdg_surface->xdg_surface->toplevel->app_id ?: "none");
 }
 
 static void handle_unmap(struct wl_listener *listener, void *data) {
@@ -468,6 +463,8 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	view_maximize(&roots_surface->view, surface->toplevel->client_pending.maximized);
 	view_set_fullscreen(&roots_surface->view, surface->toplevel->client_pending.fullscreen,
 		surface->toplevel->client_pending.fullscreen_output);
+	view_set_title(&roots_surface->view, surface->toplevel->title);
+	view_set_app_id(&roots_surface->view, surface->toplevel->app_id);
 
 	roots_surface->surface_commit.notify = handle_surface_commit;
 	wl_signal_add(&surface->surface->events.commit,

--- a/xdg_shell_v6.c
+++ b/xdg_shell_v6.c
@@ -418,11 +418,6 @@ static void handle_map(struct wl_listener *listener, void *data) {
 
 	view_map(view, roots_xdg_surface->xdg_surface_v6->surface);
 	view_setup(view);
-
-	wlr_foreign_toplevel_handle_v1_set_title(view->toplevel_handle,
-		roots_xdg_surface->xdg_surface_v6->toplevel->title ?: "none");
-	wlr_foreign_toplevel_handle_v1_set_app_id(view->toplevel_handle,
-		roots_xdg_surface->xdg_surface_v6->toplevel->app_id ?: "none");
 }
 
 static void handle_unmap(struct wl_listener *listener, void *data) {
@@ -465,6 +460,8 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	view_maximize(&roots_surface->view, surface->toplevel->client_pending.maximized);
 	view_set_fullscreen(&roots_surface->view, surface->toplevel->client_pending.fullscreen,
 		surface->toplevel->client_pending.fullscreen_output);
+	view_set_title(&roots_surface->view, surface->toplevel->title);
+	view_set_app_id(&roots_surface->view, surface->toplevel->app_id);
 
 	roots_surface->surface_commit.notify = handle_surface_commit;
 	wl_signal_add(&surface->surface->events.commit,

--- a/xwayland.c
+++ b/xwayland.c
@@ -282,11 +282,6 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		}
 
 		view_setup(view);
-
-		wlr_foreign_toplevel_handle_v1_set_title(view->toplevel_handle,
-			roots_surface->xwayland_surface->title ?: "none");
-		wlr_foreign_toplevel_handle_v1_set_app_id(view->toplevel_handle,
-			roots_surface->xwayland_surface->class ?: "none");
 	} else {
 		view_initial_focus(view);
 	}
@@ -320,6 +315,9 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	roots_surface->view.box.x = surface->x;
 	roots_surface->view.box.y = surface->y;
 	roots_surface->xwayland_surface = surface;
+
+	view_set_title(&roots_surface->view, surface->title);
+	view_set_app_id(&roots_surface->view, surface->class);
 
 	roots_surface->destroy.notify = handle_destroy;
 	wl_signal_add(&surface->events.destroy, &roots_surface->destroy);


### PR DESCRIPTION
There were missing signals for newly created surfaces and a general mess regarding who was responsible to update the handle.