### PR TITLE
Update cursor focus on popup unmap

### DIFF
--- a/layer_shell.c
+++ b/layer_shell.c
@@ -376,6 +376,7 @@ static void popup_handle_unmap(struct wl_listener *listener, void *data) {
 	int oy = popup->wlr_popup->geometry.y + layer->geo.y;
 	output_damage_whole_local_surface(output, popup->wlr_popup->base->surface,
 		ox, oy);
+	input_update_cursor_focus(output->desktop->server->input);
 }
 
 static void popup_handle_commit(struct wl_listener *listener, void *data) {

--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -43,6 +43,7 @@ static void popup_handle_map(struct wl_listener *listener, void *data) {
 static void popup_handle_unmap(struct wl_listener *listener, void *data) {
 	struct roots_xdg_popup *popup = wl_container_of(listener, popup, unmap);
 	view_damage_whole(popup->view_child.view);
+	input_update_cursor_focus(popup->view_child.view->desktop->server->input);
 }
 
 static struct roots_xdg_popup *popup_create(struct roots_view *view,

--- a/xdg_shell_v6.c
+++ b/xdg_shell_v6.c
@@ -43,6 +43,7 @@ static void popup_handle_unmap(struct wl_listener *listener, void *data) {
 	struct roots_xdg_popup_v6 *popup =
 		wl_container_of(listener, popup, unmap);
 	view_damage_whole(popup->view_child.view);
+	input_update_cursor_focus(popup->view_child.view->desktop->server->input);
 }
 
 static struct roots_xdg_popup_v6 *popup_create(struct roots_view *view,


### PR DESCRIPTION
Otherwise the cursor focus isn't updated until the next cursor
movement, which can lead to "lost" mouse clicks etc.