### PR TITLE
Refine the ordering of layer-shell surfaces

### DIFF
--- a/desktop.c
+++ b/desktop.c
@@ -99,7 +99,28 @@ static struct roots_view *desktop_view_at(struct roots_desktop *desktop,
 static struct wlr_surface *layer_surface_at(struct roots_output *output,
 		struct wl_list *layer, double ox, double oy, double *sx, double *sy) {
 	struct roots_layer_surface *roots_surface;
+
 	wl_list_for_each_reverse(roots_surface, layer, link) {
+		if (roots_surface->layer_surface->current.exclusive_zone <= 0) {
+			continue;
+		}
+
+		double _sx = ox - roots_surface->geo.x;
+		double _sy = oy - roots_surface->geo.y;
+
+		struct wlr_surface *sub = wlr_layer_surface_v1_surface_at(
+			roots_surface->layer_surface, _sx, _sy, sx, sy);
+
+		if (sub) {
+			return sub;
+		}
+	}
+
+	wl_list_for_each(roots_surface, layer, link) {
+		if (roots_surface->layer_surface->current.exclusive_zone > 0) {
+			continue;
+		}
+
 		double _sx = ox - roots_surface->geo.x;
 		double _sy = oy - roots_surface->geo.y;
 

--- a/layer_shell.c
+++ b/layer_shell.c
@@ -245,7 +245,7 @@ void arrange_layers(struct roots_output *output) {
 	size_t nlayers = sizeof(layers_above_shell) / sizeof(layers_above_shell[0]);
 	struct roots_layer_surface *layer, *topmost = NULL;
 	for (size_t i = 0; i < nlayers; ++i) {
-		wl_list_for_each_reverse(layer,
+		wl_list_for_each(layer,
 				&output->layers[layers_above_shell[i]], link) {
 			if (layer->layer_surface->current.keyboard_interactive) {
 				topmost = layer;

--- a/output.c
+++ b/output.c
@@ -164,32 +164,45 @@ void output_xwayland_children_for_each_surface(
 }
 #endif
 
+static void output_layer_handle_surface(struct roots_output *output,
+		struct roots_layer_surface *layer_surface, roots_surface_iterator_func_t iterator,
+		void *user_data) {
+	struct wlr_layer_surface_v1 *wlr_layer_surface_v1 =
+		layer_surface->layer_surface;
+	output_surface_for_each_surface(output, wlr_layer_surface_v1->surface,
+		layer_surface->geo.x, layer_surface->geo.y, iterator,
+		user_data);
+
+	struct wlr_xdg_popup *state;
+	wl_list_for_each(state, &wlr_layer_surface_v1->popups, link) {
+		struct wlr_xdg_surface *popup = state->base;
+		if (!popup->configured) {
+			continue;
+		}
+
+		double popup_sx, popup_sy;
+		popup_sx = layer_surface->geo.x;
+		popup_sx += popup->popup->geometry.x - popup->geometry.x;
+		popup_sy = layer_surface->geo.y;
+		popup_sy += popup->popup->geometry.y - popup->geometry.y;
+
+		output_surface_for_each_surface(output, popup->surface,
+			popup_sx, popup_sy, iterator, user_data);
+	}
+}
+
 void output_layer_for_each_surface(struct roots_output *output,
 		struct wl_list *layer_surfaces, roots_surface_iterator_func_t iterator,
 		void *user_data) {
 	struct roots_layer_surface *layer_surface;
+	wl_list_for_each_reverse(layer_surface, layer_surfaces, link) {
+		if (layer_surface->layer_surface->current.exclusive_zone <= 0) {
+			output_layer_handle_surface(output, layer_surface, iterator, user_data);
+		}
+	}
 	wl_list_for_each(layer_surface, layer_surfaces, link) {
-		struct wlr_layer_surface_v1 *wlr_layer_surface_v1 =
-			layer_surface->layer_surface;
-		output_surface_for_each_surface(output, wlr_layer_surface_v1->surface,
-			layer_surface->geo.x, layer_surface->geo.y, iterator,
-			user_data);
-
-		struct wlr_xdg_popup *state;
-		wl_list_for_each(state, &wlr_layer_surface_v1->popups, link) {
-			struct wlr_xdg_surface *popup = state->base;
-			if (!popup->configured) {
-				continue;
-			}
-
-			double popup_sx, popup_sy;
-			popup_sx = layer_surface->geo.x;
-			popup_sx += popup->popup->geometry.x - popup->geometry.x;
-			popup_sy = layer_surface->geo.y;
-			popup_sy += popup->popup->geometry.y - popup->geometry.y;
-
-			output_surface_for_each_surface(output, popup->surface,
-				popup_sx, popup_sy, iterator, user_data);
+		if (layer_surface->layer_surface->current.exclusive_zone > 0) {
+			output_layer_handle_surface(output, layer_surface, iterator, user_data);
 		}
 	}
 }


### PR DESCRIPTION
layer-shell doesn't define in-layer stacking order, so it's up to compositor
to come up with a sane behavior.

Ordering layer-shell surfaces in forward order works fine for shell surfaces
with exclusive zone (like panels) - however, it leads to surprising results
for ones with no exclusive zone, as the oldest surfaces are being rendered on
top of the newer ones, which is the opposite of xdg-shell behavior. Example:
a widget dashboard rendered on top of lock screen even though the lock screen
is created afterwards.

On the other hand, just using a reverse order doesn't work well when stacking
surfaces with exclusive zones - a panel with some decorative elements outside
of its exclusive zone should get rendered on top (z-index) of the panel stacked
on top (vertically) of it. For Phosh, this could result in the keyboard being
rendered on top of unfolded home screen, leading to an obviously broken visual
result.

Therefore, to follow the principle of least astonishment, layers without
exclusive-zone gets rendered first in reverse order, and then the ones stacked
to a screen edge with positive exclusive zone follow in forward order.

There's a third case: exclusive-zone set to -1, but I couldn't decide what would
be the most obvious behavior in regards to other surfaces on the same layer, so
I decided to treat them just like the ones without exclusive-zone.