### PR TITLE
seat: Handle unfocusing layer-surface with no other focusable view

### DIFF
--- a/seat.c
+++ b/seat.c
@@ -1358,7 +1358,8 @@ void roots_seat_set_focus(struct roots_seat *seat, struct roots_view *view) {
 	}
 
 	struct roots_view *prev_focus = roots_seat_get_focus(seat);
-	if (view == prev_focus) {
+
+	if (view && view == prev_focus) {
 		return;
 	}
 
@@ -1448,6 +1449,8 @@ void roots_seat_set_focus_layer(struct roots_seat *seat,
 				struct roots_seat_view *first_seat_view = wl_container_of(
 					seat->views.next, first_seat_view, link);
 				roots_seat_set_focus(seat, first_seat_view->view);
+			} else {
+				roots_seat_set_focus(seat, NULL);
 			}
 		}
 		return;


### PR DESCRIPTION
roots_seat_set_focus would exit too early in case of view == NULL and
prev_focus == NULL, not unfocusing a layer-surface that could,
for instance, lose its keyboard-interactive status.

On top of that, roots_seat_set_focus_layer wouldn't even try to reset
the focus in such cases.